### PR TITLE
bugfix(admin page): when select end date 

### DIFF
--- a/app/scripts/modules/cluster/dashboards/dashboard.admin.js
+++ b/app/scripts/modules/cluster/dashboards/dashboard.admin.js
@@ -1107,7 +1107,7 @@ angular.module('ngmReportHub')
 									currentTime: $scope.dashboard.endDate,
 									onClose: function(){
 										// set date
-										var date = moment.utc(new Date(this.currentTime)).format('YYYY-MM-DD')
+										var date = moment(new Date(this.currentTime)).format('YYYY-MM-DD')
 										if ( date !== $scope.dashboard.endDate ) {
 											// set new date
 											$scope.dashboard.endDate = date;


### PR DESCRIPTION
It's because we use moment.utc() when formating the end date, 
to solve this bug we change it to moment()